### PR TITLE
limit pytest version to < 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url='https://github.com/numirias/pytest-json-report',
     license='MIT',
     install_requires=[
-        'pytest>=4.2.0',
+        'pytest>=4.2.0,<5',
         'pytest-metadata',
     ],
     entry_points={


### PR DESCRIPTION
`pytest` uses enum based `ExitCode` that breaks this plugin

example output im getting using pytest 5.3.5
```
'exitcode': <ExitCode.TESTS_FAILED>`
```
