### PR TITLE
add support for record_property

### DIFF
--- a/pytest_jsonreport/serialize.py
+++ b/pytest_jsonreport/serialize.py
@@ -2,6 +2,16 @@
 
 """
 from collections import Counter
+import json
+
+
+def serializable(obj):
+    """Return whether `obj` is JSON-serializable."""
+    try:
+        json.dumps(obj)
+    except (TypeError, OverflowError):
+        return False
+    return True
 
 
 def make_collector(report, result):

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     flake8
     pylint
 commands =
-    flake8
+    flake8 --max-line-length 100
     pylint --rcfile tox.ini pytest_jsonreport/
 
 [testenv:release]


### PR DESCRIPTION
Note: As my knowledge of pytest-internals is very limited (to basically zero), I can't say much more than "works on my machine".

The code is inspired from what pytest itself does in the junitxml reporter. The relevant code seems to be (from `src/_pytest/junitxml.py` in function `pytest_runtest_logreport`):

```
for propname, propvalue in report.user_properties:
    reporter.add_property(propname, str(propvalue))
```