### PR TITLE
Don't crash when used with native traceback

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,11 +350,11 @@ A test stage item.
 | `duration` | Duration of the test stage in seconds. |
 | `outcome` | Outcome of the test stage. (can be different from the overall test outcome) |
 | `crash` | Crash entry. (absent if no error occurred) |
-| `traceback` | List of traceback entries. (absent if no error occurred) |
+| `traceback` | List of traceback entries. (absent if no error occurred; affected by `--tb` option) |
 | `stdout` | Standard output. (absent if none available) |
 | `stderr` | Standard error. (absent if none available) |
 | `log` | [Log](#log) entry. (absent if none available) |
-| `longrepr` | Representation of the error. (absent if no error occurred) |
+| `longrepr` | Representation of the error. (absent if no error occurred; format affected by `--tb` option) |
 
 #### Example
 

--- a/pytest_jsonreport/plugin.py
+++ b/pytest_jsonreport/plugin.py
@@ -187,20 +187,14 @@ class JSONReport(JSONReportBase):
 
     @pytest.hookimpl(trylast=True)
     def pytest_json_runtest_stage(self, report):
-        if self._must_omit('traceback'):
-            traceback = None
-        else:
-            try:
-                traceback = report.longrepr.reprtraceback
-            except AttributeError:
-                traceback = None
         stage_details = report._json_report_extra[report.when]
         return serialize.make_teststage(
             report,
+            # TODO Can we use pytest's BaseReport.capstdout/err/log here?
             stage_details.get('stdout'),
             stage_details.get('stderr'),
             stage_details.get('log'),
-            traceback,
+            self._must_omit('traceback'),
         )
 
     @pytest.hookimpl(tryfirst=True)

--- a/pytest_jsonreport/serialize.py
+++ b/pytest_jsonreport/serialize.py
@@ -94,6 +94,12 @@ def make_crash(report):
 
 def make_traceback(traceback):
     """Return JSON-serializable traceback details."""
+    if traceback.style == "native":
+        return "\n".join(
+            line
+            for entry in traceback.reprentries
+            for line in entry.lines
+        )
     return [{
         'path': entry.reprfileloc.path,
         'lineno': entry.reprfileloc.lineno,

--- a/pytest_jsonreport/serialize.py
+++ b/pytest_jsonreport/serialize.py
@@ -57,54 +57,48 @@ def make_testitem(nodeid, keywords, location):
     return item
 
 
-def make_teststage(report, stdout, stderr, log, traceback):
+def make_teststage(report, stdout, stderr, log, omit_traceback):
     """Return JSON-serializable test stage (setup/call/teardown)."""
     stage = {
         'duration': report.duration,
         'outcome': report.outcome,
     }
-    stage.update(make_crash(report))
-    if traceback:
-        stage['traceback'] = make_traceback(traceback)
+    crash = getattr(report.longrepr, 'reprcrash', None)
+    if crash is not None:
+        stage['crash'] = make_fileloc(crash)
+        if not omit_traceback:
+            try:
+                stage['traceback'] = [make_fileloc(x.reprfileloc) for x in
+                                      report.longrepr.reprtraceback.reprentries]
+            except AttributeError:
+                # Happens if no detailed tb entries are available (e.g. due to
+                # `--tb=native`, see `_pytest._code.code.ReprTracebackNative`).
+                # Then we can't provide any tb info beyond the raw error text
+                # in `longrepr`, so just pass quietly.
+                pass
     if stdout:
         stage['stdout'] = stdout
     if stderr:
         stage['stderr'] = stderr
     if log:
         stage['log'] = log
-    if report.longreprtext:
-        stage['longrepr'] = report.longreprtext
+    # Error representation string (attr is computed property, so get only once)
+    longrepr = report.longreprtext
+    if longrepr:
+        stage['longrepr'] = longrepr
     return stage
 
 
-def make_crash(report):
-    """Return JSON-serializable crash details."""
-    try:
-        crash = report.longrepr.reprcrash
-    except AttributeError:
-        return {}
+def make_fileloc(loc):
+    """Return JSON-serializable file location representation.
+
+    See `_pytest._code.code.ReprFileLocation`.
+    """
     return {
-        'crash': {
-            'path': crash.path,
-            'lineno': crash.lineno,
-            'message': crash.message,
-        },
+        'path': loc.path,
+        'lineno': loc.lineno,
+        'message': loc.message,
     }
-
-
-def make_traceback(traceback):
-    """Return JSON-serializable traceback details."""
-    if traceback.style == "native":
-        return "\n".join(
-            line
-            for entry in traceback.reprentries
-            for line in entry.lines
-        )
-    return [{
-        'path': entry.reprfileloc.path,
-        'lineno': entry.reprfileloc.lineno,
-        'message': entry.reprfileloc.message,
-    } for entry in traceback.reprentries]
 
 
 def make_summary(tests, **kwargs):
@@ -116,7 +110,7 @@ def make_summary(tests, **kwargs):
 
 
 def make_warning(warning_message, when):
-    # warning_message is a warnings.WarningMessage object
+    # `warning_message` is a stdlib warnings.WarningMessage object
     return {
         'message': str(warning_message.message),
         'category': warning_message.category.__name__,

--- a/tests/test_jsonreport.py
+++ b/tests/test_jsonreport.py
@@ -187,6 +187,23 @@ def test_report_crash_and_traceback(tests):
     assert call['traceback'] == traceback
 
 
+def test_report_traceback_styles(make_json):
+    """Handle different traceback styles (`--tb=...`)."""
+    code = '''
+        def test_raise(): assert False
+        def test_raise_nested(): f = lambda: g; f()
+    '''
+    for style in ('long', 'short'):
+        data = make_json(code, ['--json-report', '--tb=%s' % style])
+        for i in (0, 1):
+            assert isinstance(data['tests'][i]['call']['traceback'], list)
+
+    for style in ('native', 'line', 'no'):
+        data = make_json(code, ['--json-report', '--tb=%s' % style])
+        for i in (0, 1):
+            assert 'traceback' not in data['tests'][i]['call']
+
+
 def test_report_item_deselected(make_json):
     data = make_json("""
         import pytest
@@ -557,25 +574,3 @@ def test_bug_41(misc_testdir):
     """#41: Create report file path if it doesn't exist."""
     misc_testdir.runpytest('--json-report', '--json-report-file=x/report.json')
     assert (misc_testdir.tmpdir / 'x/report.json').exists()
-
-
-def test_bug_native_tb(make_json, testdir):
-    """
-    Tests that we don't crash when `--tb=native` is passed to pytest
-    """
-    test_file = """
-        def test_boom():
-            assert False is True
-    """
-    data = make_json(test_file, ['--json-report', '--tb=native'])
-    expected_traceback = """Traceback (most recent call last):
-
-  File "%(testdir)s/test_bug_native_tb.py", line 2, in test_boom
-    assert False is True
-
-AssertionError: assert False is True
-""" % {"testdir": testdir}
-    assert {
-        test['nodeid']: test['call']['traceback']
-        for test in data['tests']
-    } == {'test_bug_native_tb.py::test_boom': expected_traceback}

--- a/tests/test_jsonreport.py
+++ b/tests/test_jsonreport.py
@@ -557,3 +557,25 @@ def test_bug_41(misc_testdir):
     """#41: Create report file path if it doesn't exist."""
     misc_testdir.runpytest('--json-report', '--json-report-file=x/report.json')
     assert (misc_testdir.tmpdir / 'x/report.json').exists()
+
+
+def test_bug_native_tb(make_json, testdir):
+    """
+    Tests that we don't crash when `--tb=native` is passed to pytest
+    """
+    test_file = """
+        def test_boom():
+            assert False is True
+    """
+    data = make_json(test_file, ['--json-report', '--tb=native'])
+    expected_traceback = """Traceback (most recent call last):
+
+  File "%(testdir)s/test_bug_native_tb.py", line 2, in test_boom
+    assert False is True
+
+AssertionError: assert False is True
+""" % {"testdir": testdir}
+    assert {
+        test['nodeid']: test['call']['traceback']
+        for test in data['tests']
+    } == {'test_bug_native_tb.py::test_boom': expected_traceback}


### PR DESCRIPTION
Changes the traceback handling to also work with native trace-backs.

**WARNING: The traceback in the final report will have a different structure than what would be produced with pytest's default traceback option.**

Because the native traceback internally lacks path, lineno and message for each TB frame (it's just the line of a native Python TB) it's not easy (perhaps not even possible) to match the same format. I chose to simply report the TB as one string. Let me know if you have other preferences here.


Fixes #62 