### PR TITLE
remove useless no-report-written test summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pip install pytest-json-report --upgrade
 | `--json-report-summary` | Just create a summary without per-test details |
 | `--json-report-omit=FIELD_LIST` | List of fields to omit in the report (choose from: `collectors`, `log`, `traceback`, `streams`, `warnings`, `keywords`) |
 | `--json-report-indent=LEVEL` | Pretty-print JSON with specified indentation level |
+| `--json-report-verbosity=LEVEL` | Set verbosity (default is value of `--verbosity`) |
 
 ## Usage
 

--- a/pytest_jsonreport/plugin.py
+++ b/pytest_jsonreport/plugin.py
@@ -222,8 +222,6 @@ class JSONReport(JSONReportBase):
         path = self._config.option.json_report_file
         if path:
             self.save_report(path)
-        else:
-            self._terminal_summary.append('no JSON report written.')
 
     def save_report(self, path):
         """Save the JSON report to `path`."""
@@ -266,6 +264,8 @@ class JSONReport(JSONReportBase):
         del pytest_warning_recorded
 
     def pytest_terminal_summary(self, terminalreporter):
+        if not self._terminal_summary:
+            return
         terminalreporter.write_sep('-', 'JSON report')
         for line in self._terminal_summary:
             terminalreporter.write_line(line)

--- a/tests/test_jsonreport.py
+++ b/tests/test_jsonreport.py
@@ -36,9 +36,12 @@ def test_create_report_file_from_arg(misc_testdir):
 
 def test_create_no_report(misc_testdir):
     res = misc_testdir.runpytest('--json-report', '--json-report-file=NONE')
-    res.stdout.fnmatch_lines([
-        '*no JSON report written*',
-    ])
+
+    # no summary output
+    res.stdout.no_fnmatch_line('*-- JSON report --*')
+
+    # no more useless summary output line when generating an in-memory report
+    res.stdout.no_fnmatch_line('*no JSON report written*')
 
 
 def test_report_keys(num_processes, make_json):

--- a/tests/test_jsonreport.py
+++ b/tests/test_jsonreport.py
@@ -21,12 +21,8 @@ def test_no_report(misc_testdir):
 
 
 def test_create_report(misc_testdir):
-    res = misc_testdir.runpytest('--json-report')
+    misc_testdir.runpytest('--json-report')
     assert (misc_testdir.tmpdir / '.report.json').exists()
-
-    res.stdout.fnmatch_lines([
-        '*report written*.report.json*',
-    ])
 
 
 def test_create_report_file_from_arg(misc_testdir):
@@ -35,13 +31,28 @@ def test_create_report_file_from_arg(misc_testdir):
 
 
 def test_create_no_report(misc_testdir):
+    misc_testdir.runpytest('--json-report', '--json-report-file=NONE')
+    assert not (misc_testdir.tmpdir / '.report.json').exists()
+
+
+def test_terminal_summary(misc_testdir):
+    res = misc_testdir.runpytest('--json-report')
+    res.stdout.fnmatch_lines(['-*JSON report*-', '*report saved*.report.json*'])
+
+    res = misc_testdir.runpytest('--json-report', '--json-report-file=./')
+    res.stdout.fnmatch_lines(['*could not save report*'])
+
     res = misc_testdir.runpytest('--json-report', '--json-report-file=NONE')
+    res.stdout.no_fnmatch_line('-*JSON report*-')
 
-    # no summary output
-    res.stdout.no_fnmatch_line('*-- JSON report --*')
+    res = misc_testdir.runpytest('--json-report', '--json-report-file=NONE', '-v')
+    res.stdout.fnmatch_lines(['*auto-save skipped*'])
 
-    # no more useless summary output line when generating an in-memory report
-    res.stdout.no_fnmatch_line('*no JSON report written*')
+    res = misc_testdir.runpytest('--json-report', '-q')
+    res.stdout.no_fnmatch_line('-*JSON report*-')
+
+    res = misc_testdir.runpytest('--json-report', '-q', '--json-report-verbosity=0')
+    res.stdout.fnmatch_lines(['-*JSON report*-'])
 
 
 def test_report_keys(num_processes, make_json):


### PR DESCRIPTION
In case user requests that there is no JSON report file actually written (and instead all the collected report information is just kept stored in the plugin object - typical scenario when doing customized reporting), there is no need to add extra:
```
---------------------- JSON report ----------------------
no JSON report written.
```
filler content to the end of the pytest terminal output.