### PR TITLE
make test not expect *nix style absolute paths starting with `/`

### DIFF
--- a/tests/test_jsonreport.py
+++ b/tests/test_jsonreport.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 import sys
 import pytest
 
@@ -52,7 +53,7 @@ def test_report_keys(num_processes, make_json):
     assert set(data) == keys
     assert isinstance(data['created'], float)
     assert isinstance(data['duration'], float)
-    assert data['root'].startswith('/')
+    assert os.path.isabs(data['root'])
     assert data['exitcode'] == 1
 
 


### PR DESCRIPTION
Fixes the three failing tests on Windows. Fixes issue #65.

Unless you expect those paths to be able to come from tests running on machines running different operating systems, in which case much more involved refactoring would be needed there to figure out which machine that path came from, what OS it's running and how to parse the path in a way specific to that OS.