### PR TITLE
Expand user and env vars on configured report path

### DIFF
--- a/pytest_jsonreport/plugin.py
+++ b/pytest_jsonreport/plugin.py
@@ -244,6 +244,7 @@ class JSONReport(JSONReportBase):
         self.report = json_report
         path = self._config.option.json_report_file
         if path:
+            path = os.path.expanduser(os.path.expandvars(path))
             try:
                 self.save_report(path)
             except OSError as e:


### PR DESCRIPTION
Expand environment variables (`$FOO`) and user dirs (`~/`) passed in `--json-report-file`.

In particular, this is useful in cases where these are configured via config files (eg. `pytest.ini`) rather than being passed in directly in the command line. It also matches the behavior of `--junitxml` on pytest itself:

https://github.com/pytest-dev/pytest/blob/485c555812286003d9234b5818c9852c3256bccb/src/_pytest/junitxml.py#L475

And other similar plugins such as pytest-html:

https://github.com/pytest-dev/pytest-html/blob/8bc9a5d89b53a417c90645233597d0b506793d13/src/pytest_html/basereport.py#L22